### PR TITLE
fixed player movement

### DIFF
--- a/src/assets/images/test-level-tilemap.svg
+++ b/src/assets/images/test-level-tilemap.svg
@@ -2,12 +2,12 @@
 <!-- Created with Inkscape (http://www.inkscape.org/) -->
 
 <svg
-   width="256"
+   width="320"
    height="64"
-   viewBox="0 0 67.733332 16.933333"
+   viewBox="0 0 84.666665 16.933333"
    version="1.1"
    id="svg5"
-   inkscape:version="1.2.2 (b0a8486541, 2022-12-01)"
+   inkscape:version="1.4 (86a8ad7, 2024-10-11)"
    sodipodi:docname="test-level-tilemap.svg"
    xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
    xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
@@ -24,13 +24,13 @@
      inkscape:deskcolor="#d1d1d1"
      inkscape:document-units="px"
      showgrid="true"
-     inkscape:zoom="7.8983789"
-     inkscape:cx="162.05857"
-     inkscape:cy="33.931014"
-     inkscape:window-width="1920"
-     inkscape:window-height="1008"
-     inkscape:window-x="0"
-     inkscape:window-y="0"
+     inkscape:zoom="3.9491895"
+     inkscape:cx="171.04776"
+     inkscape:cy="40.641251"
+     inkscape:window-width="2560"
+     inkscape:window-height="1369"
+     inkscape:window-x="1912"
+     inkscape:window-y="-8"
      inkscape:window-maximized="1"
      inkscape:current-layer="layer1">
     <inkscape:grid
@@ -40,7 +40,8 @@
        spacingy="2.1166666"
        empspacing="8"
        originx="0"
-       originy="0" />
+       originy="0"
+       units="px" />
   </sodipodi:namedview>
   <defs
      id="defs2" />
@@ -120,5 +121,114 @@
        y="8.9190671e-08"
        rx="1.174986e-16"
        ry="1.174986e-16" />
+    <rect
+       style="fill:#412300;fill-opacity:1;stroke-width:1.05833"
+       id="rect3"
+       width="2.2108967"
+       height="2.2778935"
+       x="14.538321"
+       y="-15.208289" />
+    <g
+       id="g27"
+       transform="translate(-2.645834,-2.1166665)">
+      <rect
+         style="fill:#673b09;fill-opacity:1;stroke-width:1.5875;paint-order:stroke fill markers"
+         id="rect290-5"
+         width="16.933332"
+         height="16.933332"
+         x="70.379166"
+         y="2.1166666"
+         rx="1.174986e-16"
+         ry="1.174986e-16" />
+      <rect
+         style="fill:#412300;fill-opacity:1;stroke-width:1.05833"
+         id="rect14"
+         width="2.2108967"
+         height="2.2778935"
+         x="72.44104"
+         y="15.551134"
+         inkscape:spray-origin="#rect3" />
+      <rect
+         style="fill:#412300;fill-opacity:1;stroke-width:1.05833"
+         id="rect15"
+         width="2.2108967"
+         height="2.2778935"
+         x="72.788818"
+         y="10.010196"
+         inkscape:spray-origin="#rect3" />
+      <rect
+         style="fill:#412300;fill-opacity:1;stroke-width:1.05833"
+         id="rect16"
+         width="2.2108967"
+         height="2.2778935"
+         x="71.861755"
+         y="5.401782"
+         inkscape:spray-origin="#rect3" />
+      <rect
+         style="fill:#412300;fill-opacity:1;stroke-width:1.05833"
+         id="rect19"
+         width="2.2108967"
+         height="2.2778935"
+         x="75.611404"
+         y="15.252604"
+         inkscape:spray-origin="#rect3" />
+      <rect
+         style="fill:#412300;fill-opacity:1;stroke-width:1.05833"
+         id="rect20"
+         width="2.2108967"
+         height="2.2778935"
+         x="75.338638"
+         y="4.0858159"
+         inkscape:spray-origin="#rect3" />
+      <rect
+         style="fill:#412300;fill-opacity:1;stroke-width:1.05833"
+         id="rect21"
+         width="2.2108967"
+         height="2.2778935"
+         x="80.196022"
+         y="13.764143"
+         inkscape:spray-origin="#rect3" />
+      <rect
+         style="fill:#412300;fill-opacity:1;stroke-width:1.05833"
+         id="rect22"
+         width="2.2108967"
+         height="2.2778935"
+         x="83.712471"
+         y="15.411094"
+         inkscape:spray-origin="#rect3" />
+      <rect
+         style="fill:#412300;fill-opacity:1;stroke-width:1.05833"
+         id="rect25"
+         width="2.2108967"
+         height="2.2778935"
+         x="81.243149"
+         y="4.2382393"
+         inkscape:spray-origin="#rect3" />
+      <rect
+         style="fill:#1f7334;fill-opacity:1;stroke-width:1.5875;paint-order:stroke fill markers"
+         id="rect292-1"
+         width="16.933332"
+         height="4.2333331"
+         x="70.379166"
+         y="2.1166666"
+         rx="1.174986e-16"
+         ry="1.174986e-16" />
+      <rect
+         style="fill:#412300;fill-opacity:1;stroke-width:1.05833"
+         id="rect26"
+         width="2.2108967"
+         height="2.2778935"
+         x="81.04763"
+         y="9.827116"
+         inkscape:spray-origin="#rect3" />
+      <rect
+         style="fill:#412300;fill-opacity:1;stroke-width:1.05833"
+         id="rect27"
+         width="2.2108967"
+         height="2.2778935"
+         x="77.190247"
+         y="11.893559"
+         inkscape:spray-origin="#rect3" />
+    </g>
   </g>
 </svg>

--- a/src/resources/GroundPhysicsLayer.tres
+++ b/src/resources/GroundPhysicsLayer.tres
@@ -1,0 +1,3 @@
+[gd_resource type="PhysicsMaterial" format=3 uid="uid://o32qvk26lawu"]
+
+[resource]

--- a/src/resources/IcePhysicsLayer.tres
+++ b/src/resources/IcePhysicsLayer.tres
@@ -1,0 +1,4 @@
+[gd_resource type="PhysicsMaterial" format=3 uid="uid://coqhdbac5bivx"]
+
+[resource]
+friction = 0.25

--- a/src/resources/TileMapLayer.tres
+++ b/src/resources/TileMapLayer.tres
@@ -1,11 +1,10 @@
 [gd_resource type="TileSet" load_steps=5 format=3 uid="uid://gbxwj2f7pmon"]
 
 [ext_resource type="Texture2D" uid="uid://r50c0mdsxu6p" path="res://src/assets/images/test-level-tilemap.svg" id="1_3xm6f"]
+[ext_resource type="PhysicsMaterial" uid="uid://o32qvk26lawu" path="res://src/resources/GroundPhysicsLayer.tres" id="1_74l33"]
 
-[sub_resource type="PhysicsMaterial" id="PhysicsMaterial_t0xf3"]
-
-[sub_resource type="PhysicsMaterial" id="PhysicsMaterial_y60yr"]
-friction = 0.25
+[sub_resource type="TileMapPattern" id="TileMapPattern_8gswq"]
+tile_data = PackedInt32Array(0, 1, 0, 1, 1, 0, 2, 1, 0, 3, 1, 0, 4, 1, 0, 5, 1, 0, 6, 1, 0, 7, 1, 0, 8, 1, 0, 9, 1, 0, 10, 1, 0, 11, 1, 0, 12, 1, 0, 13, 1, 0, 14, 1, 0, 15, 1, 0, 16, 1, 0, 17, 1, 0, 18, 1, 0, 19, 1, 0, 20, 1, 0, 21, 1, 0, 22, 1, 0, 23, 1, 0, 24, 1, 0, 25, 1, 0, 26, 1, 0, 27, 1, 0, 28, 1, 0, 29, 1, 0, 30, 1, 0, 31, 1, 0, 32, 1, 0, 33, 1, 0, 34, 1, 0, 35, 1, 0, 36, 1, 0, 37, 1, 0, 38, 1, 0, 39, 1, 0, 40, 1, 0, 41, 1, 0, 42, 1, 0, 43, 1, 0, 44, 1, 0, 45, 1, 0, 46, 1, 0, 47, 1, 0, 48, 1, 0, 49, 1, 0, 50, 1, 0, 51, 1, 0, 52, 1, 0, 53, 1, 0, 54, 1, 0, 55, 1, 0, 56, 1, 0, 57, 1, 0, 58, 1, 0, 59, 1, 0, 60, 1, 0, 61, 1, 0, 62, 1, 0, 63, 1, 0, 64, 1, 0, 65, 1, 0, 66, 1, 0, 67, 1, 0, 68, 1, 0, 69, 1, 0, 70, 1, 0, 71, 1, 0, 72, 1, 0, 73, 1, 0, 74, 1, 0, 75, 1, 0, 76, 1, 0, 77, 1, 0, 78, 1, 0, 79, 1, 0, 80, 1, 0, 81, 1, 0, 82, 1, 0, 83, 1, 0)
 
 [sub_resource type="TileSetAtlasSource" id="TileSetAtlasSource_t0xf3"]
 texture = ExtResource("1_3xm6f")
@@ -13,14 +12,13 @@ texture_region_size = Vector2i(64, 64)
 1:0/0 = 0
 3:0/0 = 0
 2:0/0 = 0
-2:0/0/physics_layer_1/polygon_0/points = PackedVector2Array(-32, -32, 32, -32, 32, 32, -32, 32)
 0:0/0 = 0
 0:0/0/physics_layer_0/polygon_0/points = PackedVector2Array(-32, -32, 32, -32, 32, 32, -32, 32)
+4:0/0 = 0
 
 [resource]
 tile_size = Vector2i(64, 64)
 physics_layer_0/collision_layer = 2
-physics_layer_0/physics_material = SubResource("PhysicsMaterial_t0xf3")
-physics_layer_1/collision_layer = 2
-physics_layer_1/physics_material = SubResource("PhysicsMaterial_y60yr")
+physics_layer_0/physics_material = ExtResource("1_74l33")
 sources/1 = SubResource("TileSetAtlasSource_t0xf3")
+pattern_0 = SubResource("TileMapPattern_8gswq")

--- a/src/scenes/GroudTileGroup/GroudTileGroupCollision.tscn
+++ b/src/scenes/GroudTileGroup/GroudTileGroupCollision.tscn
@@ -1,0 +1,20 @@
+[gd_scene load_steps=4 format=3 uid="uid://d3vpqlfu5kpq3"]
+
+[ext_resource type="Texture2D" uid="uid://dqkk6tcxv4e6r" path="res://src/assets/images/biscuit.png" id="1_d6h86"]
+
+[sub_resource type="PhysicsMaterial" id="PhysicsMaterial_dmcma"]
+
+[sub_resource type="RectangleShape2D" id="RectangleShape2D_4jj1b"]
+size = Vector2(64, 64)
+
+[node name="GroudTileGroupCollision" type="StaticBody2D"]
+collision_layer = 2
+physics_material_override = SubResource("PhysicsMaterial_dmcma")
+
+[node name="CollisionShape2D" type="CollisionShape2D" parent="."]
+shape = SubResource("RectangleShape2D_4jj1b")
+
+[node name="Sprite2D" type="Sprite2D" parent="."]
+visible = false
+scale = Vector2(0.5, 0.5)
+texture = ExtResource("1_d6h86")

--- a/src/scenes/GroudTileGroup/GroudTileGroupCollisionEven.tscn
+++ b/src/scenes/GroudTileGroup/GroudTileGroupCollisionEven.tscn
@@ -1,0 +1,27 @@
+[gd_scene load_steps=4 format=3 uid="uid://c8y882x446654"]
+
+[ext_resource type="Texture2D" uid="uid://dqkk6tcxv4e6r" path="res://src/assets/images/biscuit.png" id="1_luhso"]
+
+[sub_resource type="PhysicsMaterial" id="PhysicsMaterial_dmcma"]
+
+[sub_resource type="RectangleShape2D" id="RectangleShape2D_4jj1b"]
+size = Vector2(128, 64)
+
+[node name="GroudTileGroupCollisionEven" type="StaticBody2D"]
+collision_layer = 2
+physics_material_override = SubResource("PhysicsMaterial_dmcma")
+
+[node name="CollisionShape2D" type="CollisionShape2D" parent="."]
+position = Vector2(32, 0)
+shape = SubResource("RectangleShape2D_4jj1b")
+
+[node name="Sprite2D" type="Sprite2D" parent="."]
+visible = false
+scale = Vector2(0.5, 0.5)
+texture = ExtResource("1_luhso")
+
+[node name="Sprite2D2" type="Sprite2D" parent="."]
+visible = false
+position = Vector2(64, 0)
+scale = Vector2(0.5, 0.5)
+texture = ExtResource("1_luhso")

--- a/src/scenes/Level_0/Level_0.tscn
+++ b/src/scenes/Level_0/Level_0.tscn
@@ -1,10 +1,13 @@
-[gd_scene load_steps=7 format=4 uid="uid://dii3527gneijh"]
+[gd_scene load_steps=10 format=4 uid="uid://dii3527gneijh"]
 
 [ext_resource type="Script" uid="uid://cyqghsbcpsxd0" path="res://src/scripts/level/level.gd" id="1_o1n0q"]
 [ext_resource type="TileSet" uid="uid://gbxwj2f7pmon" path="res://src/resources/TileMapLayer.tres" id="1_xv8l3"]
 [ext_resource type="PackedScene" uid="uid://bijdjrc81d3au" path="res://src/scenes/FinishArea/FinishArea.tscn" id="2_8cerr"]
 [ext_resource type="PackedScene" uid="uid://lfdxant4ulby" path="res://src/scenes/MarkerStart/MarkerStart.tscn" id="3_jyyny"]
 [ext_resource type="PackedScene" uid="uid://bcda1rv4kc57" path="res://src/scenes/DeathZone/DeathZone.tscn" id="3_rp8sf"]
+[ext_resource type="PackedScene" uid="uid://d3vpqlfu5kpq3" path="res://src/scenes/GroudTileGroup/GroudTileGroupCollision.tscn" id="3_v22dm"]
+[ext_resource type="PhysicsMaterial" uid="uid://o32qvk26lawu" path="res://src/resources/GroundPhysicsLayer.tres" id="4_2lu1i"]
+[ext_resource type="PackedScene" uid="uid://c8y882x446654" path="res://src/scenes/GroudTileGroup/GroudTileGroupCollisionEven.tscn" id="4_172wg"]
 
 [sub_resource type="LabelSettings" id="LabelSettings_rp8sf"]
 font_size = 24
@@ -13,8 +16,23 @@ font_size = 24
 script = ExtResource("1_o1n0q")
 
 [node name="TileMapLayer" type="TileMapLayer" parent="."]
-tile_map_data = PackedByteArray("AAAAAAAAAQAAAAAAAAABAAAAAQAAAAAAAAACAAAAAQAAAAAAAAADAAAAAQAAAAAAAAAEAAAAAQAAAAAAAAAFAAAAAQAAAAAAAAAGAAAAAQAAAAAAAAAHAAAAAQAAAAAAAAANAAAAAQAAAAAAAAAOAAAAAQAAAAAAAAAPAAAAAQAAAAAAAAAQAAAAAQAAAAAAAAAVAAAAAQAAAAAAAAAWAAAAAQAAAAAAAAAXAAAAAQAAAAAAAAAYAAAAAQAAAAAAAAAZAAAAAQAAAAAAAAAaAAAAAQAAAAAAAAAbAAAAAQAAAAAAAAAcAAAAAQAAAAAAAAAdAAAAAQAAAAAAAAAeAAAAAQAAAAAAAAAfAAAAAQAAAAAAAAAIAAAAAQAAAAAAAAAPAP//AQAAAAAAAAAQAP7/AQAAAAAAAAASAP3/AQAAAAAAAAAfAP//AQAAAAAAAAAfAP7/AQAAAAAAAAAfAP3/AQAAAAAAAAAfAPz/AQAAAAAAAAAfAPv/AQAAAAAAAAAfAPr/AQAAAAAAAAAfAPn/AQAAAAAAAAAfAPj/AQAAAAAAAAAfAPf/AQAAAAAAAAAfAPb/AQAAAAAAAAAfAPX/AQAAAAAAAADq//X/AQAAAAAAAADq//b/AQAAAAAAAADq//f/AQAAAAAAAADq//j/AQAAAAAAAADq//n/AQAAAAAAAADq//r/AQAAAAAAAADq//v/AQAAAAAAAADq//z/AQAAAAAAAADq//3/AQAAAAAAAADq//7/AQAAAAAAAADq////AQAAAAAAAADq/wAAAQAAAAAAAAAEAP//AQAAAAAAAAA=")
+tile_map_data = PackedByteArray("AAABAAAAAQAEAAAAAAACAAAAAQAEAAAAAAADAAAAAQAEAAAAAAAEAAAAAQAEAAAAAAAFAAAAAQAEAAAAAAAGAAAAAQAEAAAAAAAHAAAAAQAEAAAAAAANAAAAAQAEAAAAAAAOAAAAAQAEAAAAAAAQAAAAAQAEAAAAAAAVAAAAAQAEAAAAAAAWAAAAAQAEAAAAAAAXAAAAAQAEAAAAAAAYAAAAAQAEAAAAAAAZAAAAAQAEAAAAAAAaAAAAAQAEAAAAAAAbAAAAAQAEAAAAAAAcAAAAAQAEAAAAAAAdAAAAAQAEAAAAAAAeAAAAAQAEAAAAAAAfAAAAAQAEAAAAAAAIAAAAAQAEAAAAAAAPAP//AQAAAAAAAAAQAP7/AQAAAAAAAAASAP3/AQAAAAAAAAAfAP//AQAAAAAAAAAfAP7/AQAAAAAAAAAfAP3/AQAAAAAAAAAfAPz/AQAAAAAAAAAfAPv/AQAAAAAAAAAfAPr/AQAAAAAAAAAfAPn/AQAAAAAAAAAfAPj/AQAAAAAAAAAfAPf/AQAAAAAAAAAfAPb/AQAAAAAAAAAfAPX/AQAAAAAAAADq//X/AQAAAAAAAADq//b/AQAAAAAAAADq//f/AQAAAAAAAADq//j/AQAAAAAAAADq//n/AQAAAAAAAADq//r/AQAAAAAAAADq//v/AQAAAAAAAADq//z/AQAAAAAAAADq//3/AQAAAAAAAADq//7/AQAAAAAAAADq////AQAAAAAAAADq/wAAAQAAAAAAAAAEAP//AQAAAAAAAAAPAAAAAQAEAAAAAAAAAAAAAQAEAAAAAAA=")
 tile_set = ExtResource("1_xv8l3")
+
+[node name="GroudTileGroupCollision" parent="TileMapLayer" instance=ExtResource("3_v22dm")]
+position = Vector2(288, 32)
+scale = Vector2(9, 1.004)
+physics_material_override = ExtResource("4_2lu1i")
+
+[node name="GroudTileGroupCollision2" parent="TileMapLayer" instance=ExtResource("4_172wg")]
+position = Vector2(896, 32)
+scale = Vector2(2, 1)
+physics_material_override = ExtResource("4_2lu1i")
+
+[node name="GroudTileGroupCollision3" parent="TileMapLayer" instance=ExtResource("3_v22dm")]
+position = Vector2(1696, 32)
+scale = Vector2(11, 1)
+physics_material_override = ExtResource("4_2lu1i")
 
 [node name="MarkerStart" parent="." instance=ExtResource("3_jyyny")]
 position = Vector2(53, -68)

--- a/src/scenes/Level_1/Level_1.tscn
+++ b/src/scenes/Level_1/Level_1.tscn
@@ -1,17 +1,63 @@
-[gd_scene load_steps=6 format=4 uid="uid://tux8olgr24hu"]
+[gd_scene load_steps=10 format=4 uid="uid://tux8olgr24hu"]
 
 [ext_resource type="TileSet" uid="uid://gbxwj2f7pmon" path="res://src/resources/TileMapLayer.tres" id="1_5k248"]
 [ext_resource type="Script" uid="uid://cyqghsbcpsxd0" path="res://src/scripts/level/level.gd" id="1_xif7h"]
 [ext_resource type="PackedScene" uid="uid://bcda1rv4kc57" path="res://src/scenes/DeathZone/DeathZone.tscn" id="2_8ehf1"]
+[ext_resource type="PackedScene" uid="uid://c8y882x446654" path="res://src/scenes/GroudTileGroup/GroudTileGroupCollisionEven.tscn" id="3_ioxno"]
 [ext_resource type="PackedScene" uid="uid://bijdjrc81d3au" path="res://src/scenes/FinishArea/FinishArea.tscn" id="3_xif7h"]
+[ext_resource type="PhysicsMaterial" uid="uid://o32qvk26lawu" path="res://src/resources/GroundPhysicsLayer.tres" id="4_0b703"]
 [ext_resource type="PackedScene" uid="uid://lfdxant4ulby" path="res://src/scenes/MarkerStart/MarkerStart.tscn" id="4_5dufl"]
+[ext_resource type="PackedScene" uid="uid://d3vpqlfu5kpq3" path="res://src/scenes/GroudTileGroup/GroudTileGroupCollision.tscn" id="5_6l4cu"]
+[ext_resource type="PhysicsMaterial" uid="uid://coqhdbac5bivx" path="res://src/resources/IcePhysicsLayer.tres" id="6_v5sdh"]
 
 [node name="Level_1" type="Node2D"]
 script = ExtResource("1_xif7h")
 
 [node name="TileMapLayer" type="TileMapLayer" parent="."]
-tile_map_data = PackedByteArray("AAAAAAAAAQAAAAAAAAABAAAAAQAAAAAAAAACAAAAAQAAAAAAAAADAAAAAQAAAAAAAAAEAAAAAQAAAAAAAAAFAAAAAQAAAAAAAAAGAAAAAQACAAAAAAAHAAAAAQACAAAAAAAIAAAAAQACAAAAAAALAAAAAQACAAAAAAAMAAAAAQACAAAAAAANAAAAAQACAAAAAAAPAAAAAQAAAAAAAAAOAAIAAQAAAAAAAAAPAAIAAQAAAAAAAAAQAAIAAQAAAAAAAAARAAIAAQAAAAAAAAAPAP//AQAAAAAAAAAQAAAAAQAAAAAAAAATAAEAAQAAAAAAAAATAAIAAQAAAAAAAAATAP3/AQAAAAAAAAAUAP3/AQAAAAAAAAAVAP3/AQAAAAAAAAAVAP7/AQAAAAAAAAAVAP//AQAAAAAAAAAVAAAAAQAAAAAAAAAVAAEAAQAAAAAAAAAOAP7/AQAAAAAAAAANAP3/AQAAAAAAAAAMAP3/AQAAAAAAAAASAP3/AQAAAAAAAAARAP3/AQAAAAAAAAALAPz/AQAAAAAAAAALAPv/AQAAAAAAAAALAPr/AQAAAAAAAAALAPn/AQAAAAAAAAALAPj/AQAAAAAAAAAZAAEAAQAAAAAAAAAZAP//AQACAAAAAAAaAP//AQACAAAAAAAbAP//AQACAAAAAAAdAAEAAQACAAAAAAAgAAEAAQAAAAAAAAAgAAAAAQAAAAAAAAAgAP//AQAAAAAAAAAgAP7/AQAAAAAAAAAgAP3/AQAAAAAAAAAgAPz/AQAAAAAAAAAgAPv/AQAAAAAAAAAgAPr/AQAAAAAAAAAgAPn/AQAAAAAAAAAgAPj/AQAAAAAAAAAgAPf/AQAAAAAAAAAgAPb/AQAAAAAAAAAbAAIAAQACAAAAAAAZAAcAAQAAAAAAAAATAAsAAQAAAAAAAAAUAAoAAQAAAAAAAAAVAAcAAQAAAAAAAAAVAAoAAQAAAAAAAAAWAAoAAQAAAAAAAAAXAAoAAQAAAAAAAAAYAAoAAQAAAAAAAAAZAAgAAQACAAAAAAAZAAoAAQAAAAAAAAAaAAoAAQAAAAAAAAAbAAsAAQAAAAAAAAA=")
+tile_map_data = PackedByteArray("AAAAAAAAAQAEAAAAAAABAAAAAQAEAAAAAAACAAAAAQAEAAAAAAADAAAAAQAEAAAAAAAEAAAAAQAEAAAAAAAFAAAAAQAEAAAAAAAGAAAAAQACAAAAAAAHAAAAAQACAAAAAAAIAAAAAQACAAAAAAALAAAAAQACAAAAAAAMAAAAAQACAAAAAAANAAAAAQACAAAAAAAPAAAAAQAAAAAAAAAOAAIAAQAEAAAAAAAPAAIAAQAEAAAAAAAQAAIAAQAEAAAAAAARAAIAAQAEAAAAAAAPAP//AQAAAAAAAAAQAAAAAQAAAAAAAAATAAEAAQAAAAAAAAATAAIAAQAAAAAAAAATAP3/AQAEAAAAAAAUAP3/AQAEAAAAAAAVAP3/AQAEAAAAAAAVAP7/AQAAAAAAAAAVAP//AQAAAAAAAAAVAAAAAQAAAAAAAAAVAAEAAQAAAAAAAAAOAP7/AQAAAAAAAAANAP3/AQAEAAAAAAAMAP3/AQAEAAAAAAASAP3/AQAEAAAAAAARAP3/AQAEAAAAAAALAPz/AQAAAAAAAAALAPv/AQAAAAAAAAALAPr/AQAAAAAAAAALAPn/AQAAAAAAAAALAPj/AQAAAAAAAAAZAAEAAQAAAAAAAAAZAP//AQACAAAAAAAaAP//AQACAAAAAAAbAP//AQACAAAAAAAdAAEAAQACAAAAAAAgAAEAAQAAAAAAAAAgAAAAAQAAAAAAAAAgAP//AQAAAAAAAAAgAP7/AQAAAAAAAAAgAP3/AQAAAAAAAAAgAPz/AQAAAAAAAAAgAPv/AQAAAAAAAAAgAPr/AQAAAAAAAAAgAPn/AQAAAAAAAAAgAPj/AQAAAAAAAAAgAPf/AQAAAAAAAAAgAPb/AQAAAAAAAAAbAAIAAQACAAAAAAAZAAcAAQAAAAAAAAATAAsAAQAAAAAAAAAUAAoAAQAAAAAAAAAVAAcAAQAAAAAAAAAVAAoAAQAAAAAAAAAWAAoAAQAAAAAAAAAXAAoAAQAAAAAAAAAYAAoAAQAAAAAAAAAZAAoAAQAAAAAAAAAaAAoAAQAAAAAAAAAbAAsAAQAAAAAAAAAZAAgAAQACAAAAAAA=")
 tile_set = ExtResource("1_5k248")
+
+[node name="GroudTileGroupCollisionEven" parent="TileMapLayer" instance=ExtResource("3_ioxno")]
+position = Vector2(96, 32)
+scale = Vector2(3, 1)
+physics_material_override = ExtResource("4_0b703")
+
+[node name="GroudTileGroupCollision" parent="TileMapLayer" instance=ExtResource("5_6l4cu")]
+position = Vector2(480, 32)
+scale = Vector2(3, 1)
+physics_material_override = ExtResource("6_v5sdh")
+
+[node name="GroudTileGroupCollision2" parent="TileMapLayer" instance=ExtResource("5_6l4cu")]
+position = Vector2(800, 32)
+scale = Vector2(3, 1)
+physics_material_override = ExtResource("6_v5sdh")
+
+[node name="GroudTileGroupCollisionEven2" parent="TileMapLayer" instance=ExtResource("3_ioxno")]
+position = Vector2(960, 160)
+scale = Vector2(2, 1)
+physics_material_override = ExtResource("4_0b703")
+
+[node name="GroudTileGroupCollisionEven3" parent="TileMapLayer" instance=ExtResource("3_ioxno")]
+position = Vector2(800, -160)
+physics_material_override = ExtResource("4_0b703")
+
+[node name="GroudTileGroupCollision3" parent="TileMapLayer" instance=ExtResource("5_6l4cu")]
+position = Vector2(1248, -160)
+scale = Vector2(5, 1)
+physics_material_override = ExtResource("4_0b703")
+
+[node name="GroudTileGroupCollision4" parent="TileMapLayer" instance=ExtResource("5_6l4cu")]
+position = Vector2(1696, -32)
+scale = Vector2(3, 1)
+physics_material_override = ExtResource("6_v5sdh")
+
+[node name="GroudTileGroupCollision5" parent="TileMapLayer" instance=ExtResource("5_6l4cu")]
+position = Vector2(1888, 96)
+physics_material_override = ExtResource("6_v5sdh")
+
+[node name="GroudTileGroupCollision6" parent="TileMapLayer" instance=ExtResource("5_6l4cu")]
+position = Vector2(1760, 160)
+physics_material_override = ExtResource("6_v5sdh")
 
 [node name="DeathZone" parent="." instance=ExtResource("2_8ehf1")]
 position = Vector2(0, 1004)

--- a/src/scenes/Level_2/Level_2.tscn
+++ b/src/scenes/Level_2/Level_2.tscn
@@ -1,15 +1,14 @@
-[gd_scene load_steps=10 format=4 uid="uid://bk16o0khk06st"]
+[gd_scene load_steps=12 format=4 uid="uid://bk16o0khk06st"]
 
 [ext_resource type="Script" uid="uid://cyqghsbcpsxd0" path="res://src/scripts/level/level.gd" id="1_h00dh"]
 [ext_resource type="Texture2D" uid="uid://r50c0mdsxu6p" path="res://src/assets/images/test-level-tilemap.svg" id="2_8gd8s"]
+[ext_resource type="PackedScene" uid="uid://c8y882x446654" path="res://src/scenes/GroudTileGroup/GroudTileGroupCollisionEven.tscn" id="3_0ihjf"]
 [ext_resource type="PackedScene" uid="uid://bcda1rv4kc57" path="res://src/scenes/DeathZone/DeathZone.tscn" id="3_34gn5"]
 [ext_resource type="PackedScene" uid="uid://bijdjrc81d3au" path="res://src/scenes/FinishArea/FinishArea.tscn" id="4_7go1j"]
+[ext_resource type="PhysicsMaterial" uid="uid://o32qvk26lawu" path="res://src/resources/GroundPhysicsLayer.tres" id="4_pqvcx"]
 [ext_resource type="PackedScene" uid="uid://lfdxant4ulby" path="res://src/scenes/MarkerStart/MarkerStart.tscn" id="5_0ihjf"]
-
-[sub_resource type="PhysicsMaterial" id="PhysicsMaterial_t0xf3"]
-
-[sub_resource type="PhysicsMaterial" id="PhysicsMaterial_y60yr"]
-friction = 0.25
+[ext_resource type="PackedScene" uid="uid://d3vpqlfu5kpq3" path="res://src/scenes/GroudTileGroup/GroudTileGroupCollision.tscn" id="5_nfcqy"]
+[ext_resource type="PhysicsMaterial" uid="uid://coqhdbac5bivx" path="res://src/resources/IcePhysicsLayer.tres" id="6_gx3cd"]
 
 [sub_resource type="TileSetAtlasSource" id="TileSetAtlasSource_pqvcx"]
 texture = ExtResource("2_8gd8s")
@@ -17,24 +16,76 @@ texture_region_size = Vector2i(64, 64)
 1:0/0 = 0
 3:0/0 = 0
 2:0/0 = 0
-2:0/0/physics_layer_1/polygon_0/points = PackedVector2Array(-32, -32, 32, -32, 32, 32, -32, 32)
 0:0/0 = 0
 0:0/0/physics_layer_0/polygon_0/points = PackedVector2Array(-32, -32, 32, -32, 32, 32, -32, 32)
+4:0/0 = 0
 
 [sub_resource type="TileSet" id="TileSet_nfcqy"]
 tile_size = Vector2i(64, 64)
 physics_layer_0/collision_layer = 2
-physics_layer_0/physics_material = SubResource("PhysicsMaterial_t0xf3")
-physics_layer_1/collision_layer = 2
-physics_layer_1/physics_material = SubResource("PhysicsMaterial_y60yr")
+physics_layer_0/physics_material = ExtResource("4_pqvcx")
 sources/1 = SubResource("TileSetAtlasSource_pqvcx")
 
 [node name="Level_2" type="Node2D"]
 script = ExtResource("1_h00dh")
 
 [node name="TileMapLayer" type="TileMapLayer" parent="."]
-tile_map_data = PackedByteArray("AAAAAP//AQAAAAAAAAAHAP//AQAAAAAAAAAIAP//AQAAAAAAAAAJAP//AQAAAAAAAAAKAP//AQACAAAAAAALAP//AQACAAAAAAAMAP//AQACAAAAAAANAP//AQACAAAAAAAOAP//AQACAAAAAAAPAP//AQACAAAAAAAQAP//AQACAAAAAAARAP//AQACAAAAAAASAP//AQACAAAAAAATAP//AQACAAAAAAAUAP//AQACAAAAAAAVAP//AQACAAAAAAAWAP//AQACAAAAAAAXAP//AQACAAAAAAAYAP//AQAAAAAAAAAbAP//AQAAAAAAAAAcAP//AQAAAAAAAAAdAP//AQAAAAAAAAAeAP//AQAAAAAAAAAfAP7/AQAAAAAAAAAgAP7/AQAAAAAAAAAhAP7/AQAAAAAAAAAiAP//AQAAAAAAAAAjAP//AQAAAAAAAAD/////AQAAAAAAAAD+////AQAAAAAAAAD9////AQAAAAAAAAD8////AQAAAAAAAAABAP//AQAAAAAAAAACAP//AQAAAAAAAAADAP//AQAAAAAAAAAEAP//AQAAAAAAAAAFAP//AQAAAAAAAAAGAP//AQAAAAAAAAD8//7/AQAAAAAAAAAlAP//AQAAAAAAAAAmAP//AQAAAAAAAAAmAP7/AQAAAAAAAAD8//3/AQAAAAAAAAD8//z/AQAAAAAAAAD8//v/AQAAAAAAAAD8//r/AQAAAAAAAAD8//n/AQAAAAAAAAD8//j/AQAAAAAAAAD8//f/AQAAAAAAAAD8//b/AQAAAAAAAAD8//X/AQAAAAAAAAAoAP//AQAAAAAAAAApAP//AQAAAAAAAAArAP//AQAAAAAAAAAsAP//AQAAAAAAAAAtAP//AQAAAAAAAAAtAP3/AQAAAAAAAAAtAPz/AQAAAAAAAAAtAPv/AQAAAAAAAAAtAPr/AQAAAAAAAAAtAPj/AQAAAAAAAAAtAPT/AQAAAAAAAAApAP7/AQACAAAAAAArAP7/AQACAAAAAAApAAAAAQAAAAAAAAApAAEAAQAAAAAAAAArAAEAAQAAAAAAAAAqAAEAAQAAAAAAAAAsAAEAAQAAAAAAAAAtAAEAAQAAAAAAAAAuAAEAAQAAAAAAAAAvAAEAAQAAAAAAAAAwAAEAAQAAAAAAAAAxAAEAAQAAAAAAAAAxAAAAAQAAAAAAAAAyAAEAAQAAAAAAAAAyAAAAAQAAAAAAAAAyAP//AQAAAAAAAAAyAP7/AQAAAAAAAAAyAP3/AQAAAAAAAAAyAPz/AQAAAAAAAAAyAPv/AQAAAAAAAAAyAPr/AQAAAAAAAAAyAPn/AQAAAAAAAAAyAPj/AQAAAAAAAAAuAP7/AQAAAAAAAAAyAPT/AQAAAAAAAAAtAP7/AQAAAAAAAAAtAPn/AQAAAAAAAAAsAP7/AQAAAAAAAAAuAPT/AQAAAAAAAAAvAPT/AQAAAAAAAAAwAPT/AQAAAAAAAAAxAPT/AQAAAAAAAAAxAPz/AQAAAAAAAAAuAPr/AQAAAAAAAAAfAPv/AQAAAAAAAAAgAPz/AQAAAAAAAAAhAPz/AQAAAAAAAAAiAP7/AQAAAAAAAAAdAPf/AQAAAAAAAAAVAPf/AQAAAAAAAAAWAPf/AQAAAAAAAAAXAPf/AQAAAAAAAAAYAPf/AQAAAAAAAAAZAPf/AQAAAAAAAAAaAPf/AQAAAAAAAAAbAPf/AQAAAAAAAAAcAPf/AQAAAAAAAAAdAPj/AQAAAAAAAAAfAPj/AQAAAAAAAAAgAPj/AQACAAAAAAAhAPj/AQACAAAAAAAjAPj/AQACAAAAAAAlAPj/AQAAAAAAAAAnAPj/AQAAAAAAAAAqAPj/AQAAAAAAAAAtAPf/AQAAAAAAAAAwAPf/AQAAAAAAAAAlAP7/AQAAAAAAAAAUAPf/AQAAAAAAAAAyAPf/AQAAAAAAAAAyAPb/AQAAAAAAAAAyAPX/AQAAAAAAAAAEAP3/AQAAAAAAAAAFAP3/AQAAAAAAAAAGAP3/AQAAAAAAAAADAPv/AQACAAAAAAADAPz/AQAAAAAAAAADAP3/AQAAAAAAAAAGAPv/AQACAAAAAAAGAPz/AQAAAAAAAAA=")
+tile_map_data = PackedByteArray("AAAAAP//AQAEAAAAAAAHAP//AQAEAAAAAAAIAP//AQAEAAAAAAALAP//AQACAAAAAAAMAP//AQACAAAAAAANAP//AQACAAAAAAAOAP//AQACAAAAAAAPAP//AQACAAAAAAAQAP//AQACAAAAAAARAP//AQACAAAAAAASAP//AQACAAAAAAATAP//AQACAAAAAAAUAP//AQACAAAAAAAVAP//AQACAAAAAAAWAP//AQACAAAAAAAXAP//AQACAAAAAAAYAP//AQACAAAAAAAbAP//AQAEAAAAAAAcAP//AQAEAAAAAAAdAP//AQAEAAAAAAAeAP//AQAEAAAAAAAfAP7/AQAEAAAAAAAgAP7/AQAEAAAAAAAhAP7/AQAEAAAAAAAiAP//AQAAAAAAAAAjAP//AQAAAAAAAAD/////AQAEAAAAAAD+////AQAEAAAAAAD9////AQAEAAAAAAD8////AQAEAAAAAAABAP//AQAEAAAAAAACAP//AQAEAAAAAAADAP//AQAEAAAAAAAEAP//AQAEAAAAAAAFAP//AQAEAAAAAAAGAP//AQAEAAAAAAD8//7/AQAAAAAAAAAlAP//AQAAAAAAAAAmAP//AQAAAAAAAAAmAP7/AQAAAAAAAAD8//3/AQAAAAAAAAD8//z/AQAAAAAAAAD8//v/AQAAAAAAAAD8//r/AQAAAAAAAAD8//n/AQAAAAAAAAD8//j/AQAAAAAAAAD8//f/AQAAAAAAAAD8//b/AQAAAAAAAAD8//X/AQAAAAAAAAAoAP//AQAAAAAAAAApAP//AQAAAAAAAAArAP//AQAAAAAAAAAsAP//AQAAAAAAAAAtAP//AQAAAAAAAAAtAP3/AQAAAAAAAAAtAPz/AQAAAAAAAAAtAPv/AQAAAAAAAAAtAPr/AQAAAAAAAAAtAPj/AQAAAAAAAAAtAPT/AQAAAAAAAAApAP7/AQACAAAAAAArAP7/AQACAAAAAAApAAAAAQAAAAAAAAApAAEAAQAEAAAAAAArAAEAAQAEAAAAAAAqAAEAAQAEAAAAAAAsAAEAAQAEAAAAAAAtAAEAAQAEAAAAAAAuAAEAAQAEAAAAAAAvAAEAAQAEAAAAAAAwAAEAAQAEAAAAAAAxAAEAAQAEAAAAAAAxAAAAAQAAAAAAAAAyAAEAAQAEAAAAAAAyAAAAAQAAAAAAAAAyAP//AQAAAAAAAAAyAP7/AQAAAAAAAAAyAP3/AQAAAAAAAAAyAPz/AQAAAAAAAAAyAPv/AQAAAAAAAAAyAPr/AQAAAAAAAAAyAPn/AQAAAAAAAAAyAPj/AQAAAAAAAAAuAP7/AQAAAAAAAAAyAPT/AQAAAAAAAAAtAP7/AQAAAAAAAAAtAPn/AQAAAAAAAAAsAP7/AQAAAAAAAAAuAPT/AQAAAAAAAAAvAPT/AQAAAAAAAAAwAPT/AQAAAAAAAAAxAPT/AQAAAAAAAAAxAPz/AQAAAAAAAAAuAPr/AQAAAAAAAAAfAPv/AQAAAAAAAAAgAPz/AQAAAAAAAAAhAPz/AQAAAAAAAAAiAP7/AQAEAAAAAAAdAPf/AQAEAAAAAAAVAPf/AQAEAAAAAAAWAPf/AQAEAAAAAAAXAPf/AQAEAAAAAAAYAPf/AQAEAAAAAAAZAPf/AQAEAAAAAAAaAPf/AQAEAAAAAAAbAPf/AQAEAAAAAAAcAPf/AQAEAAAAAAAdAPj/AQAAAAAAAAAfAPj/AQAAAAAAAAAgAPj/AQACAAAAAAAhAPj/AQACAAAAAAAjAPj/AQACAAAAAAAlAPj/AQAAAAAAAAAnAPj/AQAAAAAAAAAqAPj/AQAAAAAAAAAtAPf/AQAAAAAAAAAlAP7/AQAAAAAAAAAUAPf/AQAEAAAAAAAyAPf/AQAAAAAAAAAyAPb/AQAAAAAAAAAyAPX/AQAAAAAAAAAEAP3/AQAAAAAAAAAFAP3/AQAAAAAAAAAGAP3/AQAAAAAAAAADAPv/AQACAAAAAAADAPz/AQAAAAAAAAADAP3/AQAAAAAAAAAGAPv/AQACAAAAAAAGAPz/AQAAAAAAAAAJAP//AQAEAAAAAAAKAP//AQACAAAAAAA=")
 tile_set = SubResource("TileSet_nfcqy")
+
+[node name="GroudTileGroupCollisionEven" parent="TileMapLayer" instance=ExtResource("3_0ihjf")]
+position = Vector2(-32, -32)
+scale = Vector2(7, 1)
+physics_material_override = ExtResource("4_pqvcx")
+
+[node name="GroudTileGroupCollision2" parent="TileMapLayer" instance=ExtResource("5_nfcqy")]
+position = Vector2(1120, -32)
+scale = Vector2(15, 1)
+physics_material_override = ExtResource("6_gx3cd")
+
+[node name="GroudTileGroupCollisionEven2" parent="TileMapLayer" instance=ExtResource("3_0ihjf")]
+position = Vector2(1792, -32)
+scale = Vector2(2, 1)
+physics_material_override = ExtResource("4_pqvcx")
+
+[node name="GroudTileGroupCollisionEven3" parent="TileMapLayer" instance=ExtResource("3_0ihjf")]
+position = Vector2(2048, -96)
+scale = Vector2(2, 1)
+physics_material_override = ExtResource("4_pqvcx")
+
+[node name="GroudTileGroupCollisionEven4" parent="TileMapLayer" instance=ExtResource("3_0ihjf")]
+position = Vector2(2784, 96)
+scale = Vector2(5, 1)
+physics_material_override = ExtResource("4_pqvcx")
+
+[node name="GroudTileGroupCollision3" parent="TileMapLayer" instance=ExtResource("5_nfcqy")]
+position = Vector2(2656, -96)
+physics_material_override = ExtResource("6_gx3cd")
+
+[node name="GroudTileGroupCollision4" parent="TileMapLayer" instance=ExtResource("5_nfcqy")]
+position = Vector2(2784, -96)
+physics_material_override = ExtResource("6_gx3cd")
+
+[node name="GroudTileGroupCollision5" parent="TileMapLayer" instance=ExtResource("5_nfcqy")]
+position = Vector2(2272, -480)
+physics_material_override = ExtResource("6_gx3cd")
+
+[node name="GroudTileGroupCollisionEven5" parent="TileMapLayer" instance=ExtResource("3_0ihjf")]
+position = Vector2(2080, -480)
+physics_material_override = ExtResource("6_gx3cd")
+
+[node name="GroudTileGroupCollisionEven6" parent="TileMapLayer" instance=ExtResource("3_0ihjf")]
+position = Vector2(1440, -544)
+scale = Vector2(5, 1)
+physics_material_override = ExtResource("4_pqvcx")
+
+[node name="GroudTileGroupCollision6" parent="TileMapLayer" instance=ExtResource("5_nfcqy")]
+position = Vector2(224, -288)
+physics_material_override = ExtResource("6_gx3cd")
+
+[node name="GroudTileGroupCollision7" parent="TileMapLayer" instance=ExtResource("5_nfcqy")]
+position = Vector2(416, -288)
+physics_material_override = ExtResource("6_gx3cd")
 
 [node name="DeathZone" parent="." instance=ExtResource("3_34gn5")]
 position = Vector2(1566, 380)

--- a/src/scenes/Main/Main.tscn
+++ b/src/scenes/Main/Main.tscn
@@ -12,9 +12,9 @@
 [sub_resource type="Resource" id="Resource_4lipg"]
 script = ExtResource("2_bb7lw")
 levelName = &"Level 0"
-trophyTime_gold = 5.0
-trophyTime_silver = 8.0
-trophyTime_bronze = 14.871
+trophyTime_gold = 6.0
+trophyTime_silver = 10.0
+trophyTime_bronze = 16.0
 resource = ExtResource("3_5llug")
 metadata/_custom_type_script = "uid://d03ckdfnx2ux5"
 

--- a/src/scenes/Player/Player.tscn
+++ b/src/scenes/Player/Player.tscn
@@ -133,6 +133,4 @@ libraries = {
 &"": SubResource("AnimationLibrary_77nyl")
 }
 
-[connection signal="body_entered" from="Area2D" to="RigidBody2D" method="_on_area_2d_body_entered"]
-[connection signal="body_exited" from="Area2D" to="RigidBody2D" method="_on_area_2d_body_exited"]
 [connection signal="animation_finished" from="HoDSprite2D/AnimationPlayer" to="." method="_on_animation_player_animation_finished"]

--- a/src/scenes/Player/player.gd
+++ b/src/scenes/Player/player.gd
@@ -3,7 +3,7 @@ class_name Player extends RigidBody2D
 @export var torqePower = 35000
 @export var forcePower = 1000
 @export var jumpForcePower = 500
-var onGround = true
+var groundCollider: Area2D
 
 # var screenSize
 
@@ -18,7 +18,7 @@ func process_move(_dt: float) -> void:
   if Input.is_action_pressed('ui_right'):
     forceDirX += 1
 
-  if Input.is_action_just_pressed('jump') && onGround:
+  if Input.is_action_just_pressed('jump') && groundCollider.has_overlapping_bodies():
     apply_impulse(Vector2(0, -jumpForcePower))
     
   if forceDirX != 0:
@@ -29,12 +29,6 @@ func process_move(_dt: float) -> void:
     
 func _physics_process(dt: float) -> void:
   process_move(dt)
-
-func _on_area_2d_body_entered(_body: Node2D) -> void:
-  onGround = true
-
-func _on_area_2d_body_exited(_body: Node2D) -> void:
-  onGround = false
 
 func level_init(pos: Vector2):
   set_deferred('freeze', true)

--- a/src/scenes/Player/playerRoot.gd
+++ b/src/scenes/Player/playerRoot.gd
@@ -6,6 +6,7 @@ signal player_death_animation_finished
 
 func _ready() -> void:
   player = $RigidBody2D
+  player.groundCollider = $Area2D
 
 func level_init(pos: Vector2):
   player.level_init(pos)


### PR DESCRIPTION
+ uninterrupted group of ground tiles now share one collision box
+ added new group collision boxes
+ player no longer checks if on ground by relying on signals, instead uses method from area2d (fixes player not always jumping when key is pressed)
+ updated level times
+ added new ground tile in atlas
+ made collision settings for ground and ice reusable resources